### PR TITLE
Network and placement functions with all agents

### DIFF
--- a/src/Modeler.js
+++ b/src/Modeler.js
@@ -160,6 +160,15 @@ export function checkErr(err, config, simulate) {
   }
 }
 
+/**
+ * @param {{ [x: string]: SubModelType } | undefined} submodels
+ *
+ * @returns {SAgent[]}
+ */
+function mergeSubmodelAgents(submodels) {
+  if (!submodels) return []
+  return Object.values(submodels).flatMap(submodel => submodel.agents)
+}
 
 /**
  * @param {import("./Simulator").Simulator} simulate
@@ -550,10 +559,12 @@ function innerRunSimulation(simulate, config) {
       }
     }
 
+    const allAgents = mergeSubmodelAgents(model.submodels)
+
     for (let submodel in model.submodels) {
       if (submodel !== "base") {
         try {
-          buildNetwork(model.submodels[submodel], simulate);
+          buildNetwork({ ...model.submodels[submodel], agents: allAgents }, simulate);
         } catch (err) {
           let msg = "An error with the custom network function prevented the simulation from running.";
           if (err instanceof ModelError) {
@@ -569,7 +580,7 @@ function innerRunSimulation(simulate, config) {
 
 
         try {
-          buildPlacements(model.submodels[submodel], simulate);
+          buildPlacements({ ...model.submodels[submodel], agents: allAgents }, simulate);
         } catch (err) {
           let msg = "An error with the agent placement function prevented the simulation from running.";
           if (err instanceof ModelError) {


### PR DESCRIPTION
This PR allows the network and placement functions to access all agents in the model, and not just between ones in the same base.

(It has not been tested, but @scottfr you are welcome to give your first opinion!)

Closes #12